### PR TITLE
Change markdown breaks from true to false

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -36,7 +36,7 @@ module.exports = function (eleventyConfig) {
 		"md",
 		markdown({
 			html: true,
-			breaks: true,
+			breaks: false,
 			linkify: true,
 		}).use(markdownItAnchor, {
 			slugify: str => slugify(str),


### PR DESCRIPTION
Now it is possible with double whitespaces to enforce a newline but not
every newline in the markdown file automatically creates one.

And it is also better for the responsiveness of the page, because line
breaks based in the markdown does not break when they "want".


Actual:

![image](https://user-images.githubusercontent.com/5683677/142176026-bc2cffa8-abef-4a2f-a03a-a738ea9d5e24.png)

<!--

Thanks for contributing to the Urlaubsverwaltung Landingpage.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to info@urlaubsverwaltung.cloud with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'

 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'

If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
