### PR TITLE
Improve / Add title for each page

### DIFF
--- a/src/_includes/layout-subpage.hbs
+++ b/src/_includes/layout-subpage.hbs
@@ -4,7 +4,7 @@
 <head>
   {{> meta}}
 	<title>
-		Urlaubsverwaltung{{#if title}} - {{title}}{{/if}}
+		{{#if title}}{{title}} | {{/if}}Urlaubsverwaltung
 	</title>
 	<link rel="preload" href="/static/font/raleway/Raleway-SemiBold.woff2" as="font" type="font/woff2" crossorigin />
 	<link rel="preload" href="/static/font/raleway/Raleway-Bold.woff2" as="font" type="font/woff2" crossorigin />

--- a/src/_includes/layout.hbs
+++ b/src/_includes/layout.hbs
@@ -4,7 +4,7 @@
 <head>
   {{> meta}}
 	<title>
-		Urlaubsverwaltung{{#if title}} - {{title}}{{/if}}
+		{{#if title}}{{title}} | {{/if}}Urlaubsverwaltung
 	</title>
 	<link rel="preload" href="/static/font/raleway/Raleway-SemiBold.woff2" as="font" type="font/woff2" crossorigin />
 	<link rel="preload" href="/static/font/raleway/Raleway-Bold.woff2" as="font" type="font/woff2" crossorigin />

--- a/src/demo.hbs
+++ b/src/demo.hbs
@@ -1,6 +1,7 @@
 ---
 layout: layout
 backgroundColor: bg-sky-50
+title: Demo
 ---
 
 {{> partials/navigation active="demo" }}

--- a/src/hilfe/abteilungen/abteilungen.md
+++ b/src/hilfe/abteilungen/abteilungen.md
@@ -2,6 +2,7 @@
 layout: layout-wissensbasis
 breadcrumb:
   title: Abteilungen
+title: Abteilungen - Hilfe
 ---
 
 ## Wie kann eine Abteilung angelegt werden?

--- a/src/hilfe/abwesenheiten/abwesenheiten.md
+++ b/src/hilfe/abwesenheiten/abwesenheiten.md
@@ -2,6 +2,7 @@
 layout: layout-wissensbasis
 breadcrumb:
   title: Abwesenheit
+title: Abwesenheit - Hilfe
 ---
 
 ## Wer genehmigt eine Abwesenheit?

--- a/src/hilfe/benachrichtigungen/benachrichtigungen.md
+++ b/src/hilfe/benachrichtigungen/benachrichtigungen.md
@@ -2,6 +2,7 @@
 layout: layout-wissensbasis
 breadcrumb:
   title: Benachrichtigungen
+title: Benachrichtigungen - Hilfe
 ---
 
 ## Wie kann ich den E-Mail-Versand für bestimmte Benutzer deaktivieren?

--- a/src/hilfe/benutzer/benutzer.md
+++ b/src/hilfe/benutzer/benutzer.md
@@ -2,6 +2,7 @@
 layout: layout-wissensbasis
 breadcrumb:
   title: Benutzer
+title: Benutzer - Hilfe
 ---
 
 ## Welche Berechtigungen gibt es?

--- a/src/hilfe/drucken/drucken.md
+++ b/src/hilfe/drucken/drucken.md
@@ -2,6 +2,7 @@
 layout: layout-wissensbasis
 breadcrumb:
   title: Drucken
+title: Drucken - Hilfe
 ---
 
 ## Gibt es die Möglichkeit Ausdrucke zu erstellen?

--- a/src/hilfe/feiertage/feiertage.md
+++ b/src/hilfe/feiertage/feiertage.md
@@ -2,6 +2,7 @@
 layout: layout-wissensbasis
 breadcrumb:
   title: Feiertage
+title: Feiertage - Hilfe
 ---
 
 ## Wie kann ich die Feiertage für die Urlaubsverwaltung konfigurieren?

--- a/src/hilfe/index.hbs
+++ b/src/hilfe/index.hbs
@@ -5,6 +5,7 @@ navigation:
   activeItem: hilfe
 stylesheets:
   - /static/css/faq.css
+title: Hilfe
 ---
 
 <div class="mb-16">

--- a/src/hilfe/kalender/kalender.md
+++ b/src/hilfe/kalender/kalender.md
@@ -2,6 +2,7 @@
 layout: layout-wissensbasis
 breadcrumb:
   title: Kalender
+title: Kalender - Hilfe
 ---
 
 ## Kalenderfreigabe

--- a/src/hilfe/krankmeldungen/krankmeldungen.md
+++ b/src/hilfe/krankmeldungen/krankmeldungen.md
@@ -2,6 +2,7 @@
 layout: layout-wissensbasis
 breadcrumb:
   title: Krankmeldungen
+title: Krankmeldungen - Hilfe
 ---
 
 ## Wird an das Ende der Lohnfortzahlung erinnert?

--- a/src/hilfe/onboarding/onboarding.md
+++ b/src/hilfe/onboarding/onboarding.md
@@ -2,6 +2,7 @@
 layout: layout-wissensbasis
 breadcrumb:
   title: Onboarding
+title: Onboarding - Hilfe
 ---
 
 

--- a/src/hilfe/sso/azuread/azuread.md
+++ b/src/hilfe/sso/azuread/azuread.md
@@ -2,6 +2,7 @@
 layout: layout-wissensbasis
 breadcrumb:
   title: SSO mit Azure AD
+title: Azure AD - Single Sign-On (SSO) - Hilfe
 ---
 
 ## Single Sign-On mit Azure Active Directory (Azure AD)

--- a/src/hilfe/sso/sso.md
+++ b/src/hilfe/sso/sso.md
@@ -2,6 +2,7 @@
 layout: layout-wissensbasis
 breadcrumb:
   title: Single Sign-On (SSO)
+title: Single Sign-On (SSO) - Hilfe
 ---
 
 ## Welchen Vorteil habe ich durch die Verwendung von Single Sign-On?

--- a/src/hilfe/ueberstunden/ueberstunden.md
+++ b/src/hilfe/ueberstunden/ueberstunden.md
@@ -2,6 +2,7 @@
 layout: layout-wissensbasis
 breadcrumb:
   title: Überstunden
+title: Überstunden - Hilfe
 ---
 
 ## Gibt es die Möglichkeit Überstunden zu erfassen?

--- a/src/neuigkeiten/index.hbs
+++ b/src/neuigkeiten/index.hbs
@@ -6,6 +6,7 @@ backgroundColor: bg-sky-50
 navigation:
   activeItem: neuigkeiten
 draft: false
+title: Neuigkeiten
 ---
 
 <div class="flex flex-col md:flex-row">

--- a/src/preis.hbs
+++ b/src/preis.hbs
@@ -5,6 +5,7 @@ navigation:
   activeItem: preis
 stylesheets:
   - /static/css/faq.css
+title: Preis
 ---
 
 <div class="mb-16 md:mb-24">


### PR DESCRIPTION
Put the relevant part on the start like "Hilfe | Urlaubsverwaltung"
instead of "Urlaubsverwaltung | Hilfe"


